### PR TITLE
Update which sections get shown

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -4,8 +4,8 @@ formatter: markdown table
 header-from: INFO.md
 
 sections:
-  hide: [providers]
-  show: []
+  hide: []
+  show: [header, requirements, inputs, outputs]
 
 sort:
   enabled: true


### PR DESCRIPTION
We've implemented some more aggressive updating procedures which is
leading to more clashes with the README when multiple module update PRs
are opened.

I don't think we're interested in modules and resources, they're
implementation details really, so I've updated the configuration to only
document the module's interfaces: custom documentation, requirements,
variables, and outputs.
